### PR TITLE
Allow multiple data types for an argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ docs/_build
 
 # VS Code
 .vscode/
+
+# Test ninfo.ini
+ninfo.ini

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ pip-log.txt
 *.db
 
 docs/_build
+
+# Virtual environment
+.venv/
+
+# VS Code
+.vscode/

--- a/ninfo/__init__.py
+++ b/ninfo/__init__.py
@@ -7,10 +7,7 @@ logger = logging.getLogger("ninfo")
 
 import os
 
-try:
-    import ConfigParser
-except ImportError:
-    import configparser as ConfigParser
+import configparser as ConfigParser
 
 from mako.template import Template
 

--- a/ninfo/__init__.py
+++ b/ninfo/__init__.py
@@ -11,7 +11,6 @@ try:
     import ConfigParser
 except ImportError:
     import configparser as ConfigParser
-import configparser as ConfigParser
 
 from mako.template import Template
 

--- a/ninfo/__init__.py
+++ b/ninfo/__init__.py
@@ -7,6 +7,10 @@ logger = logging.getLogger("ninfo")
 
 import os
 
+try:
+    import ConfigParser
+except ImportError:
+    import configparser as ConfigParser
 import configparser as ConfigParser
 
 from mako.template import Template

--- a/ninfo/util.py
+++ b/ninfo/util.py
@@ -15,7 +15,10 @@ def ishash(arg):
     return bool(_hash_re.match(arg))
 
 def get_type(arg):
-    """Return the type of the argument (mac, ip, hostname, url, hostport, or username)"""
+    """Return a list of possible types for the type of the
+    argument (mac, ip, hostname, url,hostport, and/or username)"""
+
+    potential_types = []
 
     ip_types = {
         (4, False): "ip",
@@ -25,25 +28,25 @@ def get_type(arg):
     }
 
     if ieeemac.ismac(arg):
-        return 'mac'
+        potential_types.append("mac")
     #macs can look like hashes, so check them first
     if ishash(arg):
-        return 'hash'
+        potential_types.append("hash")
     ipver = isip(arg)
     if ipver:
-        return ip_types[(ipver, '/' in arg)]
+        potential_types.append(ip_types[(ipver, "/" in arg)])
 
     parts = arg.split(':')
     if len(parts) == 2 and parts[1].isdigit():
-        return 'hostport'
+        potential_types.append("hostport")
 
     if '://' in arg:
-        return 'url'
+        potential_types.append("url")
 
     if '.' in arg:
-        return 'hostname'
+        potential_types.append("hostname")
     
-    return 'username'
+    potential_types.append("username")
 
 def is_local(networks, ip):
     """Return True if `ip` is in `networks`"""

--- a/ninfo/util.py
+++ b/ninfo/util.py
@@ -48,6 +48,8 @@ def get_type(arg):
     
     potential_types.append("username")
 
+    return potential_types
+
 def is_local(networks, ip):
     """Return True if `ip` is in `networks`"""
     for n in networks:

--- a/ninfo/util.py
+++ b/ninfo/util.py
@@ -37,13 +37,11 @@ def get_type(arg):
         potential_types.append(ip_types[(ipver, "/" in arg)])
 
     parts = arg.split(':')
-    if len(parts) == 2 and parts[1].isdigit():
-        potential_types.append("hostport")
-
     if '://' in arg:
         potential_types.append("url")
-
-    if '.' in arg:
+    elif len(parts) == 2 and parts[1].isdigit():
+        potential_types.append("hostport")
+    elif '.' in arg:
         potential_types.append("hostname")
     
     potential_types.append("username")

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -1,25 +1,29 @@
 import ninfo
 from tests.common import Wrapper
-from nose.tools import eq_
-
-test_plugins = {
-    "a": Wrapper("tests.plug_a"),
-}
 
 def test_plugin_cloning_no_config():
+    test_plugins = {
+        "a": Wrapper("tests.plug_a"),
+    }
     n=ninfo.Ninfo(plugin_modules=test_plugins)
     assert 'a' in n
     assert 'b' not in n
 
 def test_plugin_cloning_with_config():
+    test_plugins = {
+        "a": Wrapper("tests.plug_a"),
+    }
     n=ninfo.Ninfo(plugin_modules=test_plugins, config_file="tests/clone.cfg")
     assert 'a' in n
     assert 'b' in n
 
 def test_plugin_cloning_cloned_config():
+    test_plugins = {
+        "a": Wrapper("tests.plug_a"),
+    }
     n=ninfo.Ninfo(plugin_modules=test_plugins, config_file="tests/clone.cfg")
     a = n.get_plugin('a')
     b = n.get_plugin('b')
 
-    eq_(a.plugin_config, {"one": '1', "two": '2'})
-    eq_(b.plugin_config, {"clone": 'a', "one": 'one', "two": '2', "three": '3'})
+    assert a.plugin_config == {"one": '1', "two": '2'}
+    assert b.plugin_config == {"clone": 'a', "one": 'one', "two": '2', "three": '3'}

--- a/tests/test_ninfo.py
+++ b/tests/test_ninfo.py
@@ -1,13 +1,10 @@
 import ninfo
 from tests.common import Wrapper
 
-from nose.tools import eq_
-
-test_plugins = {
-    "a": Wrapper("tests.plug_a"),
-}
-
 def test_plugin_loading():
+    test_plugins = {
+        "a": Wrapper("tests.plug_a"),
+    }
     n=ninfo.Ninfo(plugin_modules=test_plugins)
     assert 'a' in n
     assert 'b' not in n
@@ -19,6 +16,9 @@ def test_plugin_loading():
     assert plugin is None
 
 def test_plugin_lazy_loading():
+    test_plugins = {
+        "a": Wrapper("tests.plug_a"),
+    }
     n=ninfo.Ninfo(plugin_modules=test_plugins)
     assert 'a' in n
     assert 'a' not in n.plugin_instances
@@ -28,6 +28,9 @@ def test_plugin_lazy_loading():
     assert 'a' in n.plugin_instances
 
 def test_plugin_lazy_init():
+    test_plugins = {
+        "a": Wrapper("tests.plug_a"),
+    }
     n=ninfo.Ninfo(plugin_modules=test_plugins)
     plugin = n.get_plugin('a')
     assert plugin is not None
@@ -38,14 +41,17 @@ def test_plugin_lazy_init():
     res = n.get_info("a", "example.com")
     assert plugin.initialized is True
 
-    eq_(res, "AAAAAAAAAAA")
+    assert res == "AAAAAAAAAAA"
 
 def test_plugin_compatible_types():
+    test_plugins = {
+        "a": Wrapper("tests.plug_a"),
+    }
     n=ninfo.Ninfo(plugin_modules=test_plugins)
 
     cases = [
         ("example.com", True),
-        ("1.2.3.4", False),
+        ("1.2.3.4", True),
         ("00:11:22:33:44:55", False),
     ]
     for arg, expected in cases:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,5 @@
-from nose.tools import eq_
 from ninfo import util
+
 def test_is_ip():
     cases = (
         ("1.2.3.4", 4),
@@ -14,7 +14,7 @@ def test_is_ip():
         yield ip_case, ip, valid
 
 def ip_case(ip, valid):
-    eq_(util.isip(ip), valid)
+    assert util.isip(ip) == valid
 
 def test_get_type():
     cases = (
@@ -34,7 +34,7 @@ def test_get_type():
         yield type_case, x, t
 
 def type_case(x, expected_type):
-    eq_(util.get_type(x), expected_type)
+    assert expected_type in util.get_type(x)
 
 
 import IPy


### PR DESCRIPTION
@Goggin, these changes should address the issues we discussed with certain computer object names being identified as hashes.

Rather than assign the argument a data type, it assigns it a list of possible data types, so a plugin can operate on any argument that matches its supported data type, even if that wouldn't be the first data type as detected previously.

In order to confirm that test were still passing, I had to update update nose to nose2.  According to https://nose.readthedocs.io/en/latest/, nose is in maintenance mode.  nose2 appears to be the successor, and running nose2 -v shows that all tests are passing.

Let me know if you have any questions or want to go over this together.