### PR TITLE
Fix argspec argtype hostname

### DIFF
--- a/ninfo/__init__.py
+++ b/ninfo/__init__.py
@@ -17,7 +17,12 @@ except ImportError:
 
 from mako.template import Template
 
-import inspect
+try:
+    from inspect import getargspec
+except ImportError:
+    from inspect import getfullargspec as getargspec
+
+from inspect import getsourcefile
 
 from ninfo import util
 import IPy
@@ -129,7 +134,7 @@ class PluginBase(object):
         return out
 
     def get_template(self, output_type):
-        code = inspect.getsourcefile(self.__class__)
+        code = getsourcefile(self.__class__)
         path = os.path.dirname(code)
         filename = "%s_template_%s.mako" % (self._name, output_type)
         template = os.path.join(path, filename)
@@ -299,7 +304,7 @@ class Ninfo:
 
         try:
             plugin_obj.init()
-            get_info_args = len(inspect.getargspec(plugin_obj.get_info)[0])
+            get_info_args = len(getargspec(plugin_obj.get_info)[0])
             if get_info_args == 3:
                 # This plugin supports context.
                 ret = plugin_obj.get_info(arg, options)

--- a/ninfo/__init__.py
+++ b/ninfo/__init__.py
@@ -1,6 +1,6 @@
 from pkg_resources import iter_entry_points
 
-__version__ = "0.8.1"
+__version__ = "0.9.0"
 
 import memcache
 

--- a/ninfo/util.py
+++ b/ninfo/util.py
@@ -46,7 +46,7 @@ def get_type(arg):
         potential_types.append("url")
     elif len(parts) == 2 and parts[1].isdigit():
         potential_types.append("hostport")
-    elif "." in arg:
+    elif "." in arg and not ipver:
         potential_types.append("hostname")
 
     potential_types.append("username")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ninfo"
-version = "0.8.1"
+version = "0.9.0"
 description = "Plugin based information gathering library"
 readme = "README.md"
 authors = [{ name = "Justin Azoff", email = "justin.azoff@gmail.com" }, { name = "Ryan Goggin", email = "support@ryangoggin.net" }]
@@ -35,7 +35,7 @@ Homepage = "https://github.com/ninfo-py/ninfo"
 ninfo = "ninfo:main"
 
 [tool.bumpver]
-current_version = "0.8.1"
+current_version = "0.9.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message  = "Bump version {old_version} -> {new_version}"
 commit          = true

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='ninfo',
-    version='0.8.1',
+    version='0.9.0',
     zip_safe=False,
     description="Plugin based information gathering library",
     packages = find_packages(exclude=["tests"]),


### PR DESCRIPTION
    Fix getargspec and hostname being type for ip

    - In newer python, getargspec replaced with getfullargspec
    - get_type was adding "hostname" when type was ip